### PR TITLE
fixes CircleAverageMaterialProperty in parallel

### DIFF
--- a/tests/userobjects/circle_average_material_property/tests
+++ b/tests/userobjects/circle_average_material_property/tests
@@ -3,7 +3,13 @@
     type = 'CSVDiff'
     input = 'circle_average_material_property.i'
     csvdiff = 'circle_average_material_property_out.csv'
-    max_parallel = 2
+  [../]
+  [./circle_average_material_property_parallel]
+    type = 'CSVDiff'
+    input = 'circle_average_material_property.i'
+    csvdiff = 'circle_average_material_property_out.csv'
+    prereq = circle_average_material_property
+    min_parallel = 2
   [../]
   [./points_from_inserter]
     type = 'CSVDiff'


### PR DESCRIPTION
This is way simpler. Don't know what I was thinking.

Also uses std::map::at which is C++11!

closes #24 