### PR TITLE
Mark elements containing sinks and events

### DIFF
--- a/include/userobjects/SinkMapUserObject.h
+++ b/include/userobjects/SinkMapUserObject.h
@@ -37,11 +37,16 @@ public:
 
   Real getDistanceToNearestSink(const Point & p) const;
 
+  Point getNearestSinkLocation(const Point & p) const;
+
   Real getStrength() const { return _strength; }
 
   const MooseEnum & getPlacement() const { return _sink_placement; }
 
 protected:
+  /// Get info on neatest sink to a Point
+  std::pair<Real, Point> getNearestSink(const Point & p) const;
+
   /// Distance between sink centers
   const Real _spacing;
 

--- a/src/markers/EventMarker.C
+++ b/src/markers/EventMarker.C
@@ -156,7 +156,7 @@ EventMarker::computeElementMarker()
     else
       r = _mesh.minPeriodicDistance(_periodic_var, _event_location, centroid);
 
-    if (r < _refine_distance)  // we are near the event
+    if ((r < _refine_distance) || (_current_elem->contains_point(_event_location))) // we are near the event or element contains event
     {
       if (!_refine_by_ratio)  // refine if distance is the only critereon
         marker_value = REFINE;

--- a/src/markers/EventMarker.C
+++ b/src/markers/EventMarker.C
@@ -192,8 +192,11 @@ EventMarker::computeElementMarker()
     // get distance to nearest sink
     Real r = _sink_map_user_object_ptr->getDistanceToNearestSink(centroid);
 
+    // get location of nearest sink
+    Point nearest_sink = _sink_map_user_object_ptr->getNearestSinkLocation(centroid);
+
     // refine if close enough
-    if (r < _sink_refine_distance) // we are near a sink
+    if ((r < _sink_refine_distance) || (_current_elem->contains_point(nearest_sink))) // we are near a sink or element contains the nearest sink
     {
       if (marker_value == COARSEN) // no coarsening occurs during initial refinement, so sinks are already refined and we need to negate coarsening of nearby event
         marker_value = DO_NOTHING;

--- a/src/userobjects/SinkMapUserObject.C
+++ b/src/userobjects/SinkMapUserObject.C
@@ -163,7 +163,22 @@ SinkMapUserObject::getLocalSinkMap(const Elem * elem) const
 Real
 SinkMapUserObject::getDistanceToNearestSink(const Point & p) const
 {
+  std::pair<Real, Point> sink = getNearestSink(p);
+  return sink.first;
+}
+
+Point
+SinkMapUserObject::getNearestSinkLocation(const Point & p) const
+{
+  std::pair<Real, Point> sink = getNearestSink(p);
+  return sink.second;
+}
+
+std::pair<Real, Point>
+SinkMapUserObject::getNearestSink(const Point & p) const
+{
   Real r, rmin = std::numeric_limits<Real>::max();
+  Point nearest_sink_location;
 
   // to do 3D lines, need to change z-component of point to that of a sink
   // so the distance to the line is based on the xy-plane distance
@@ -181,7 +196,10 @@ SinkMapUserObject::getDistanceToNearestSink(const Point & p) const
           (new_p - _sink_location_list[i]).norm() :
           _mesh.minPeriodicDistance(_periodic_var, new_p, _sink_location_list[i]);
     if (r < rmin)
+    {
       rmin = r;
+      nearest_sink_location = _sink_location_list[i];
+    }
   }
-  return rmin;
+  return std::make_pair(rmin, nearest_sink_location);
 }


### PR DESCRIPTION
Fixes case where a sink is too far from an element centroid when using very small sigma. Now at least the element containing the sink will be marked.

closes #58 