### PR TITLE
fix EventTimeStepper to work when maxdt is set

### DIFF
--- a/include/timesteppers/EventTimeStepper.h
+++ b/include/timesteppers/EventTimeStepper.h
@@ -52,6 +52,9 @@ protected:
   /// Flag if dt was cut
   bool _was_dt_cut;
 
+  /// timestep computed by computeDT
+  Real _new_dt;
+
   /// Pointer to EventInserter UserObject
   const EventInserter * _inserter_ptr;
 };

--- a/tests/timesteppers/event_timestepper_dtmax.i
+++ b/tests/timesteppers/event_timestepper_dtmax.i
@@ -1,0 +1,137 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = -1
+  xmax = 1
+  ymin = -1
+  ymax = 1
+  nx = 2
+  ny = 2
+  elem_type = QUAD4
+[]
+
+[Variables]
+  active = 'u'
+
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+
+    [./InitialCondition]
+      type = ConstantIC
+      value = 0
+    [../]
+  [../]
+[]
+
+[Functions]
+  [./forcing_fn]
+    type = ParsedFunction
+    # dudt = 3*t^2*(x^2 + y^2)
+    value = 3*t*t*((x*x)+(y*y))-(4*t*t*t)
+  [../]
+
+  [./exact_fn]
+    type = ParsedFunction
+    value = t*t*t*((x*x)+(y*y))
+  [../]
+[]
+
+[Kernels]
+  active = 'diff ie ffn'
+
+  [./ie]
+    type = TimeDerivative
+    variable = u
+  [../]
+
+  [./diff]
+    type = Diffusion
+    variable = u
+  [../]
+
+  [./ffn]
+    type = UserForcingFunction
+    variable = u
+    function = forcing_fn
+  [../]
+[]
+
+[BCs]
+  active = 'all'
+
+  [./all]
+    type = FunctionDirichletBC
+    variable = u
+    boundary = '0 1 2 3'
+    function = exact_fn
+  [../]
+
+  [./left]
+    type = DirichletBC
+    variable = u
+    boundary = 3
+    value = 0
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = u
+    boundary = 1
+    value = 1
+  [../]
+[]
+
+[UserObjects]
+  [./random_point_uo]
+    type = RandomPointUserObject
+    seed = 1
+  [../]
+  [./inserter]
+    type = EventInserter
+    random_timing = false
+    mean = 10.0
+    random_point_user_object = random_point_uo
+    seed = 1
+    verbose = true
+  [../]
+[]
+
+
+[Executioner]
+  type = Transient
+  scheme = 'implicit-euler'
+
+  # Preconditioned JFNK (default)
+  solve_type = 'PJFNK'
+
+  start_time = 0.0
+  end_time = 12.0
+  dtmax = 2.0
+
+  verbose = true
+
+  [./TimeStepper]
+    type = EventTimeStepper
+    dt = 1.0
+    event_inserter = inserter
+    growth_factor = 2.0
+    verbose = true
+  [../]
+[]
+
+[Postprocessors]
+  [./l2_err]
+    type = ElementL2Error
+    variable = u
+    function = exact_fn
+  [../]
+  [./dt]
+    type = TimestepSize
+  [../]
+[]
+
+[Outputs]
+  csv = true
+  execute_on = 'initial timestep_end'
+[]


### PR DESCRIPTION
put in a check to see if dt returned by EventTimeStepper::computeDT() has been reduced when it is called again.

Also use _dt instead of getCurrentDT() because getCurrentDT() is not changed if the executioner changes _dt

closes #62 