### PR TITLE
keep entries in event list at all times

### DIFF
--- a/include/userobjects/EventInserter.h
+++ b/include/userobjects/EventInserter.h
@@ -70,6 +70,9 @@ public:
   /// Returns time of last event in list
   Real getMaxEventTime() const;
 
+  /// Print out event lists
+  void printEventLists() const;
+
 protected:
   /// Timing to use between event
   const bool _use_random_timing;


### PR DESCRIPTION
Swap in the new event in place of the old one. Also print out more event info in verbose mode. 

closes #91 
