### PR TITLE
script for testing recovery in parallel

### DIFF
--- a/problems/test_recovery_and_parallel/test.i
+++ b/problems/test_recovery_and_parallel/test.i
@@ -1,0 +1,247 @@
+[Mesh]
+  type = GeneratedMesh
+  dim = 2
+  xmin = -0.5
+  xmax = 0.5
+  ymin = -0.5
+  ymax = 0.5
+  nx = 20
+  ny = 20
+[]
+
+[Variables]
+  [./u]
+    order = FIRST
+    family = LAGRANGE
+
+    [./InitialCondition]
+      type = ConstantIC
+      value = 0
+    [../]
+  [../]
+[]
+
+[AuxVariables]
+  [./sink_map_aux]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+  [./sink_map_rate_aux]
+    order = CONSTANT
+    family = MONOMIAL
+  [../]
+[]
+
+[Kernels]
+  [./ie]
+    type = TimeDerivative
+    variable = u
+  [../]
+
+  [./diff]
+    type = MaterialDiffusion
+    variable = u
+    diffusivity_name = diffusivity
+  [../]
+
+  [./sink_map]
+    type = SinkMapKernel
+    variable = u
+    sink_map_user_object = sink_map_uo
+    diffusivity_name = diffusivity
+  [../]
+
+  [./event_inserter_source]
+    type = EventInserterSource
+    variable = u
+    inserter = inserter
+    gaussian_user_object = gaussian_uo
+  [../]
+[]
+
+[AuxKernels]
+  [./sink_map]
+    type = SinkMapAux
+    variable = sink_map_aux
+    sink_map_user_object = sink_map_uo
+    execute_on = timestep_end
+  [../]
+  [./sink_map_rate]
+    type = SinkMapRateAux
+    variable = sink_map_rate_aux
+    diffusivity_name = diffusivity
+    sink_map_user_object = sink_map_uo
+    solution_variable = u
+    execute_on = timestep_end
+  [../]
+[]
+
+[BCs]
+  [./Periodic]
+    [./all]
+      variable = u
+      auto_direction = 'x y'
+    [../]
+  [../]
+[]
+
+[Materials]
+  [./simple]
+    type = GenericConstantMaterial
+    block = 0
+    prop_names = 'diffusivity'
+    prop_values = '2.0'
+  [../]
+[]
+
+[UserObjects]
+  [./inserter_circle_average]
+    type = CircleAverageMaterialProperty
+    mat_prop = diffusivity
+    periodic_variable = u
+    inserter = inserter
+    radius = 0.2
+  [../]
+  [./circle_average]
+    type = CircleAverageMaterialProperty
+    mat_prop = diffusivity
+    periodic_variable = u
+  [../]
+  [./random_point_uo]
+    type = RandomPointUserObject
+    seed = 1
+  [../]
+  [./gaussian_uo]
+    type = GaussianUserObject
+    sigma = 0.05
+    periodic_variable = u
+    scale = 3
+  [../]
+  [./sink_gaussian_uo]
+    type = GaussianUserObject
+    sigma = 0.05
+  [../]
+  [./circle_max_original_element_size_uo]
+    type = CircleMaxOriginalElementSize
+    periodic_variable = u
+  [../]
+  [./inserter]
+    type = EventInserter
+    insert_initial = true
+    random_timing = true
+    mean = 1.2
+    random_point_user_object = random_point_uo
+    seed = 3
+    verbose = true
+    track_old_events = true
+    removal_method = sigma_element_size_ratio
+    removal_sigma_element_size_ratio = 1.0
+    radius = 3.0
+    gaussian_user_object = gaussian_uo
+    circle_average_material_property_user_object = circle_average
+    inserter_circle_average_material_property_user_object = inserter_circle_average
+    circle_max_original_element_size_user_object = circle_max_original_element_size_uo
+  [../]
+  [./sink_map_uo]
+    type = SinkMapUserObject
+    spacing = 1.0
+    strength = 0.05
+    sink_placement = inside
+    gaussian_user_object = sink_gaussian_uo
+  [../]
+[]
+
+[Adaptivity]
+  initial_marker = event_marker
+  initial_steps = 10
+  marker = event_marker
+  cycles_per_step = 10
+  max_h_level = 0
+  recompute_markers_during_cycles = true
+  [./Markers]
+    [./event_marker]
+      type = EventMarker
+      inserter = inserter
+      gaussian_user_object = gaussian_uo
+      marker_radius = 6.0
+      coarsen_events = true
+      verbose = true
+      periodic_variable = u
+      event_sigma_mesh_ratio = 1.0
+      refine_sinks = true
+      sink_marker_radius = 6.0
+      sink_map_user_object = sink_map_uo
+      sink_gaussian_user_object = sink_gaussian_uo
+      sink_sigma_mesh_ratio = 1.0
+    [../]
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  scheme = 'implicit-euler'
+
+  solve_type = 'NEWTON'
+
+  start_time = 0.0
+  num_steps = 10
+
+  verbose = true
+
+  petsc_options_iname = '-pc_type -pc_hypre_type'
+  petsc_options_value = 'hypre boomeramg'
+
+  nl_abs_tol = 1.0e-12
+
+  [./TimeStepper]
+    type = EventTimeStepper
+    dt = 0.01
+    event_inserter = inserter
+    growth_factor = 2.0
+  [../]
+[]
+
+[Preconditioning]
+  [./smp]
+    type = SMP
+    full = true
+  [../]
+[]
+
+[Postprocessors]
+  [./dt]
+    type = TimestepSize
+  [../]
+  [./solution_integral]
+    type = ElementIntegralVariablePostprocessor
+    variable = u
+  [../]
+  [./solution_average]
+    type = ElementAverageValue
+    variable = u
+  [../]
+  [./sink_integral]
+    type = ElementIntegralVariablePostprocessor
+    variable = sink_map_aux
+  [../]
+  [./sink_average]
+    type = ElementAverageValue
+    variable = sink_map_aux
+  [../]
+  [./num_elems]
+    type = NumElems
+  [../]
+  [./sink_rate_average]
+    type = ElementAverageValue
+    variable = sink_map_rate_aux
+  [../]
+[]
+
+[Outputs]
+  exodus = true
+  execute_on = 'initial timestep_end'
+  [./console]
+    type = Console
+    print_mesh_changed_info = true
+  [../]
+[]

--- a/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
+++ b/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# enter these parameters
+runs=10
+max_cpus=4
+max_steps=20
+
+for ((run=1;run<=$runs;run++))
+do
+  for ((cpus=1;cpus<=$max_cpus;cpus++))
+  do
+    for ((steps=2;steps<=$max_steps;steps++))
+    do
+      # clean
+      rm -rf *.e* *_cp run run-recover exodus-output
+
+      # get some random numbers for seeding the RNG's
+      seed1=$RANDOM
+      seed2=$RANDOM
+      echo "run $run using $steps steps on $cpus cpu's with these seeds: $seed1 $seed2 ..."
+
+      # run once all the way through
+      echo "running all the way through..."
+      mpiexec -np $cpus ../../PRARIEDOG-opt -i test.i Executioner/num_steps=$steps Outputs/file_base=gold UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 > run
+
+      # count exodus output files
+      num_gold_files=`for file in gold.e*; do echo $file; done | wc -l`
+
+      # do half-transient and recover
+      echo "running a half-transient and recover..."
+      mpiexec -np $cpus ../../PRARIEDOG-opt -i test.i Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --half-transient Outputs/checkpoint=true > run-recover
+      mpiexec -np $cpus ../../PRARIEDOG-opt -i test.i Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2--recover  >> run-recover
+
+      # count exodus output files again
+      num_recover_files=`for file in recover.e*; do echo $file; done | wc -l`
+
+      # number of output files should be the same
+      if [ $num_gold_files != $num_recover_files ]
+      then
+          echo "error: number of output files does not match"
+          exit
+      fi
+
+      if [ $num_gold_files -gt 1 ]
+      then
+          gold_file=gold.e-s`printf "%03d" $num_gold_files`
+          recover_file=recover.e-s`printf "%03d" $num_gold_files`
+      else
+          gold_file=gold.e
+          recover_file=recover.e
+      fi
+
+      # now compare the last files the same way the moose tester does it
+      # this assumes you have this app installed next to moose
+      ../../../moose/framework/contrib/exodiff/exodiff -m  -F 1e-10 -t 5.5e-06 $gold_file $recover_file > exodiff-output
+
+      # check for message in exodiff output
+      if ! grep -q 'Files are the same' exodiff-output
+      then
+          echo "error: outputs are different"
+          exit
+      else
+          echo "OK!"
+      fi
+
+    done
+  done
+done


### PR DESCRIPTION
Uses input file from 2d_sink_map_with_refinement example, except with random timing. It gets run several times with increasing number of num_steps, then over increasing number of cpus, and then all that gets run again as many times as needed. Should tease out any weird combinations of adaptivity/timestepping/recovery after enough runs.

As is, the diffusion coefficient is high enough that event refinement is only on for one step. Might want to tweak that later, as well as other parameters.

closes #117