### PR TITLE
make CircleAverageMaterialProperty execute at timestep_begin

### DIFF
--- a/include/userobjects/CircleAverageMaterialProperty.h
+++ b/include/userobjects/CircleAverageMaterialProperty.h
@@ -115,10 +115,10 @@ protected:
   std::map<dof_id_type, Point> _centroids;
 
   /// This vector will hold integral around inserter points
-  std::vector<Real> & _integral_sum;
+  std::vector<Real> _integral_sum;
 
   /// This vector will hold volume around inserter points
-  std::vector<Real> & _volume_sum;
+  std::vector<Real> _volume_sum;
 
   /// List of old events
   EventList _old_event_list;


### PR DESCRIPTION
CircleAverageMaterialProperty now explicitly executes at **both** timestep_begin and timestep_end. When doing this at timestep_begin, it has access to the adapted mesh and is ready when EventInserter executes. Also forces a map update when recovering, so it doesn't need to be made recoverable. The timestep_end is really only there because so CircleAverageMaterialPropertyPPS can access the latest values.

closes #124 