### PR TITLE
More general recovery testing script

### DIFF
--- a/problems/test_recovery_and_parallel/run_one_case.sh
+++ b/problems/test_recovery_and_parallel/run_one_case.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+if [ $# -ne 3 ]
+then
+  echo "usage: $0 num_steps seed1 seed2"
+  exit
+fi
+
+steps=$1
+seed1=$2
+seed2=$3
+
+rm -rf *.e* *_cp run run-recover exodus-output
+
+echo "run using $steps steps with these seeds: $seed1 $seed2 ..."
+
+# run once all the way through
+echo "running all the way through..."
+../../PRARIEDOG-opt -i test.i Executioner/num_steps=$steps Outputs/file_base=gold UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 > run
+
+
+# do half-transient and recover
+echo "running a half-transient and recover..."
+../../PRARIEDOG-opt -i test.i Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --half-transient Outputs/checkpoint=true > run-recover
+../../PRARIEDOG-opt -i test.i Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --recover  >> run-recover
+
+# count exodus output files
+num_gold_files=`for file in gold.e*; do echo $file; done | wc -l`
+num_recover_files=`for file in recover.e*; do echo $file; done | wc -l`
+
+# number of output files should be the same
+if [ $num_gold_files != $num_recover_files ]
+then
+  echo "error: number of output files does not match, cpus: $cpus, steps: $steps, seeds: $seed1 $seed2"
+  exit 1
+fi
+
+if [ $num_gold_files -gt 1 ]
+then
+  gold_file=gold.e-s`printf "%03d" $num_gold_files`
+  recover_file=recover.e-s`printf "%03d" $num_gold_files`
+else
+  gold_file=gold.e
+  recover_file=recover.e
+fi
+
+# now compare the last files the same way the moose tester does it
+# this assumes you have this app installed next to moose
+../../../moose/framework/contrib/exodiff/exodiff -m  -F 1e-10 -t 5.5e-06 $gold_file $recover_file > exodiff-output
+
+# check for message in exodiff output
+if ! grep -q 'Files are the same' exodiff-output
+then
+  echo "error: outputs are different, cpus: $cpus, steps: $steps, seeds: $seed1 $seed2"
+  exit 1
+else
+  echo "OK!"
+fi

--- a/problems/test_recovery_and_parallel/run_one_case.sh
+++ b/problems/test_recovery_and_parallel/run_one_case.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This script is to be used to run one set of simulations to test recovery.
+# It requires 3 parameters from the command line (in this order):
+#   1. total number of steps to perform
+#   2. seed 1
+#   3. seed 2
+
 if [ $# -ne 3 ]
 then
   echo "usage: $0 num_steps seed1 seed2"

--- a/problems/test_recovery_and_parallel/test.i
+++ b/problems/test_recovery_and_parallel/test.i
@@ -33,6 +33,7 @@
 []
 
 [Kernels]
+  active = 'ie diff event_inserter_source'
   [./ie]
     type = TimeDerivative
     variable = u
@@ -90,7 +91,7 @@
     type = GenericConstantMaterial
     block = 0
     prop_names = 'diffusivity'
-    prop_values = '2.0'
+    prop_values = '0.2'
   [../]
 []
 
@@ -153,9 +154,9 @@
 
 [Adaptivity]
   initial_marker = event_marker
-  initial_steps = 10
+  initial_steps = 1
   marker = event_marker
-  cycles_per_step = 10
+  cycles_per_step = 1
   max_h_level = 0
   recompute_markers_during_cycles = true
   [./Markers]

--- a/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
+++ b/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# This script is for testing the robustness of PRARIEDOG in terms of recovery.
+# It can do several loops over the input file for a range of steps and numbers of cpus
+#   to test if the recovery works with timestepping, mesh adaptivity, etc...
+# It picks random seeds for the cascade timing and location objects, so it is best to
+#   do several iterations ("runs").
+
 # enter these parameters
 runs=1
 max_cpus=1

--- a/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
+++ b/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # enter these parameters
-runs=10
-max_cpus=4
-max_steps=20
+runs=1
+max_cpus=1
+max_steps=10
 
 # choose executable type (e.g. "opt" or "dbg")
 exec_type=opt
@@ -73,12 +73,12 @@ do
   done
 done
 
+# print results
+echo "-----------------"
 if [ -e "failed-tests" ]
 then
-  echo "-----------------"
   echo "summary:"
   cat failed-tests
 else
-  echo "-----------------"
   echo "no errors!"
 fi

--- a/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
+++ b/problems/test_recovery_and_parallel/test_recover_and_parallel.sh
@@ -5,12 +5,19 @@ runs=1
 max_cpus=1
 max_steps=10
 
-# choose executable type (e.g. "opt" or "dbg")
-exec_type=opt
+# set path to executable
+exec=../../PRARIEDOG-opt
+
+# set path to exodiff
+exodiff=../../../moose/framework/contrib/exodiff/exodiff
+
+# set name of input file
+inputfile=test.i
 
 # write information on failed tests to file
 rm -f failed-tests
 
+# loop
 for ((run=1;run<=$runs;run++))
 do
   for ((cpus=1;cpus<=$max_cpus;cpus++))
@@ -27,15 +34,15 @@ do
 
       # run once all the way through
       echo "running all the way through..."
-      mpiexec -np $cpus ../../PRARIEDOG-$exec_type -i test.i Executioner/num_steps=$steps Outputs/file_base=gold UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 > run
+      mpiexec -np $cpus $exec -i $inputfile Executioner/num_steps=$steps Outputs/file_base=gold UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 > run
 
       # count exodus output files
       num_gold_files=`for file in gold.e*; do echo $file; done | wc -l`
 
       # do half-transient and recover
       echo "running a half-transient and recover..."
-      mpiexec -np $cpus ../../PRARIEDOG-$exec_type -i test.i Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --half-transient Outputs/checkpoint=true > run-recover
-      mpiexec -np $cpus ../../PRARIEDOG-$exec_type -i test.i Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --recover  >> run-recover
+      mpiexec -np $cpus $exec -i $inputfile Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --half-transient Outputs/checkpoint=true > run-recover
+      mpiexec -np $cpus $exec -i $inputfile Executioner/num_steps=$steps Outputs/file_base=recover UserObjects/random_point_uo/seed=$seed1 UserObjects/inserter/seed=$seed2 --recover  >> run-recover
 
       # count exodus output files again
       num_recover_files=`for file in recover.e*; do echo $file; done | wc -l`
@@ -47,6 +54,7 @@ do
           continue
       fi
 
+      # get name of last exodus file
       if [ $num_gold_files -gt 1 ]
       then
           gold_file=gold.e-s`printf "%03d" $num_gold_files`
@@ -58,7 +66,7 @@ do
 
       # now compare the last files the same way the moose tester does it
       # this assumes you have this app installed next to moose
-      ../../../moose/framework/contrib/exodiff/exodiff -m  -F 1e-10 -t 5.5e-06 $gold_file $recover_file > exodiff-output
+      $exodiff -m  -F 1e-10 -t 5.5e-06 $gold_file $recover_file > exodiff-output
 
       # check for message in exodiff output
       if ! grep -q 'Files are the same' exodiff-output


### PR DESCRIPTION
Now one needs to set the path to the executables at the top of the recovery scripts. This allows one to copy the script to a different directory and do recovery testing there.

Closes #129 