### PR TITLE
fix for broken example problems

### DIFF
--- a/src/userobjects/InserterPointCircleAverageMaterialProperty.C
+++ b/src/userobjects/InserterPointCircleAverageMaterialProperty.C
@@ -53,8 +53,6 @@ InserterPointCircleAverageMaterialProperty::averageValue(const Point & p) const
   for (unsigned int i=0; i<_event_list.size(); i++)
     if (p.absolute_fuzzy_equals(_event_list[i].second))
       return _integral_sum[i]/_volume_sum[i];
-    else
-      return 0.0;  // in case volume postprocessor hasn't been run
 
   // if we made it here, the point wasn't found
   mooseError("In InserterPointCircleAverageMaterialProperty::averageValue(), Point", p, "not found");


### PR DESCRIPTION
Was coding late at night and thought I was putting in a check for a zero denominator. Now in InserterPointCircleAverageMaterialProperty, if a property is requested around an Inserter point, only return something if that point is found. Otherwise throw error.

closes #155 